### PR TITLE
Escape paths which are removed by SVN

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ svn add . --force > /dev/null
 
 # SVN delete all deleted files
 # Also suppress stdout here
-svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm % > /dev/null
+svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
 
 # Copy tag locally to make this a single commit
 echo "➤ Copying tag..."


### PR DESCRIPTION
While digging into what was causing "a peg revision is not allowed here" during deployment I stumbled upon issue #13 

I noticed that the actual files I was adding didn't have any problem with using `@` signs, but SVN removing files did.

This PR simply adds an escape character to the file path when removing file in SVN.

This is might solve the issue for the person who opened the bug report too.