### PR TITLE
Add zip generation steps to output zip_path, Closes #34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:stable-slim
 
 RUN apt-get update \
-	&& apt-get install -y subversion rsync git \
+	&& apt-get install -y subversion rsync git zip \
 	&& apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,18 @@
 name: 'WordPress Plugin Deploy'
 description: 'Deploy to the WordPress Plugin Repository'
 author: '10up'
+inputs:
+  generate-zip:
+    description: 'Generate package zip file?'
+    default: false
+outputs:
+  zip_path:
+    description: 'Zip file path'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.generate-zip }}
 branding:
   icon: 'upload-cloud'
   color: 'blue'


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Add zip generation steps to output `zip_path` so it can be used for further other actions.

### Alternate Designs

Generating zip is optional and it can be opt-in only with generate-zip true:

```yml
with:
  generate-zip: true
```

### Benefits

It can be used for further other actions. See this workflow and watch the commented area:

```yml
name: Deploy to WordPress.org
on:
  release:
    types: [published]
jobs:
  tag:
    name: New tag
    runs-on: ubuntu-latest
    steps:
    - name: Checkout code
      uses: actions/checkout@v2
    - name: Build # To build my project.
      run: |
        npm install
        npm run build
    - name: WordPress Plugin Deploy
      id: deploy # ID to supply in other steps.
      uses: 10up/action-wordpress-plugin-deploy@master
      with:
        generate-zip: true # boolean so users can opt-out of generation zip which is by default.
      env:
        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
    - name: Upload release asset
      uses: actions/upload-release-asset@v1
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      with:
        upload_url: ${{ github.event.release.upload_url }}
        asset_path: ${{ steps.deploy.outputs.zip_path }} # here to implement zip path from deploy step.
        asset_name: ${{ github.event.repository.name }}.zip
        asset_content_type: application/zip
```

### Possible Drawbacks

None that I can think of.

### Verification Process

I read through the entrypoint file in the Action referenced but otherwise just going to let it test by opening this PR and seeing what happens.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #4 

https://github.com/10up/actions-wordpress/issues/8

### Changelog Entry

> Added - Zip generation steps to output zip_path.
