### PR TITLE
Suggestion: --quiet instead of > /dev/null

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,11 +103,11 @@ fi
 # The force flag ensures we recurse into subdirectories even if they are already added
 # Suppress stdout in favor of svn status later for readability
 echo "➤ Preparing files..."
-svn add . --force > /dev/null
+svn add . --force --quiet
 
 # SVN delete all deleted files
 # Also suppress stdout here
-svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
+svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ --quiet
 
 # Copy tag locally to make this a single commit
 echo "➤ Copying tag..."


### PR DESCRIPTION
* I think the commands will output serious errors with `--quiet` and not just suppress everything. SVN says it displays nothing or just a summary so it's probably a good fit here. I prefer it in general for all commands that have it from what I learned.
* Redirecting to /dev/null means the output is still written and then discarded, that's less efficient than not writing it (and not allocate, prepare that output to be written)

[Source for 2nd point and more info on this](https://unix.stackexchange.com/questions/191254/why-do-many-commands-provide-a-quiet-option)
