### PR TITLE
Fix screenshots getting force downloaded

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,6 +113,11 @@ svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
 echo "➤ Copying tag..."
 svn cp "trunk" "tags/$VERSION"
 
+# Fix screenshots getting force downloaded when clicking them
+# https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
+svn propset svn:mime-type image/png assets/*.png || true
+svn propset svn:mime-type image/jpeg assets/*.jpg || true
+
 svn status
 
 echo "➤ Committing files..."


### PR DESCRIPTION
Fix screenshots getting force downloaded when clicking them https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/

I guess its best run last b4 commit. The `|| true` is because it will fail if there is nothing to do no images (probably both, not sure). So it will not stop the entire script.