### PR TITLE
Fix ZIP generation and add to readme

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,9 +129,9 @@ svn commit -m "Update to version $VERSION from GitHub" --no-auth-cache --non-int
 if ! $GENERATE_ZIP; then
   echo "Generating zip file..."
   cd "$SVN_DIR/trunk" || exit
-  zip -r "${SLUG}.zip" "$SLUG/"
+  zip -r "${GITHUB_WORKSPACE}/${SLUG}.zip" .
   # Set GitHub "zip_path" output
-  echo "::set-output name=zip_path::$SVN_DIR/${SLUG}.zip"
+  echo "::set-output name=zip_path::$GITHUB_WORKSPACE/${SLUG}.zip"
   echo "✓ Zip file generated!"
 fi
 


### PR DESCRIPTION
### Description of the Change

Fixes issues with ZIP generation stemming from various paths.

### Alternate Designs

Looked at running the ZIP command without navigating into `trunk` but it retained full file paths and didn't seem worth the extra cruft to avoid that.

### Benefits

Actually get ZIP generation working.

### Possible Drawbacks

n/a

### Verification Process

Ran command locally - however, will only find out if we've missed something in the output parameter setting after doing a live test run.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

See #37 

### Changelog Entry


