### PR TITLE
Fix path for ZIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ steps.deploy.outputs.zip_path }}
+        asset_path: ${{github.workspace}}/${{ github.event.repository.name }}.zip
         asset_name: ${{ github.event.repository.name }}.zip
         asset_content_type: application/zip
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -130,8 +130,6 @@ if ! $GENERATE_ZIP; then
   echo "Generating zip file..."
   cd "$SVN_DIR/trunk" || exit
   zip -r "${GITHUB_WORKSPACE}/${SLUG}.zip" .
-  # Set GitHub "zip_path" output
-  echo "::set-output name=zip_path::$GITHUB_WORKSPACE/${SLUG}.zip"
   echo "✓ Zip file generated!"
 fi
 


### PR DESCRIPTION
### Description of the Change

Because of the Docker mapping the path `$GITHUB_WORKSPACE` in Bash is not the same as the path of `github.workspace` in the webhook payload. So, let's use the latter instead of trying to be smart with the path. If we want to avoid being so direct with the reference, I think we would need to upload and download the ZIP as an artifact which seems like a lot of unnecessary work to me. cc @shivapoudel 

### Alternate Designs

See above.

### Benefits

Actually make #42 and #37 work.

### Possible Drawbacks

More config to potentially break in individual workflow files themselves, I guess?

### Verification Process

Ran a stripped down version of this in a test repo.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#4 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
