### PR TITLE
Feat/add custom workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 * `SLUG` - defaults to the repository name, customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `VERSION` - defaults to the tag name; do not recommend setting this except for testing purposes.
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
+* `WORKSPACE_DIR` - defaults to `$GITHUB_WORKSPACE`, customizable for other locations. 
 
 ## Excluding files from deployment
 If there are files or directories to be excluded from deployment, such as tests or editor config files, they can be specified in either a `.distignore` file or a `.gitattributes` file using the `export-ignore` directive. If a `.distignore` file is present, it will be used; if not, the Action will look for a `.gitattributes` file and barring that, will write a basic temporary `.gitattributes` into place before proceeding so that no Git/GitHub-specific files are included.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,6 +62,9 @@ cd "$SVN_DIR"
 svn update --set-depth infinity assets
 svn update --set-depth infinity trunk
 
+echo "➤ Current working directory"
+pwd
+
 echo "➤ Copying files..."
 if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
 	echo "ℹ︎ Using .distignore"
@@ -129,8 +132,10 @@ svn cp "trunk" "tags/$VERSION"
 
 # Fix screenshots getting force downloaded when clicking them
 # https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
-svn propset svn:mime-type image/png assets/*.png || true
-svn propset svn:mime-type image/jpeg assets/*.jpg || true
+if test -n "$(find . -maxdepth 1 -name 'glob*' -print -quit)"; then
+	svn propset svn:mime-type image/png assets/*.png || true
+	svn propset svn:mime-type image/jpeg assets/*.jpg || true
+fi
 
 svn status
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 if [[ -z "$WORKSPACE_DIR" ]]; then
 	WORKSPACE_DIR=$GITHUB_WORKSPACE
 fi
-echo "ℹ︎ $WORKSPACE_DIR is $GITHUB_WORKSPACE"
+echo "ℹ︎ WORKSPACE_DIR is $WORKSPACE_DIR"
 
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="/github/svn-${SLUG}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,6 +71,7 @@ if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
 else
 	echo "ℹ︎ Using .gitattributes"
 
+	cd "$GITHUB_WORKSPACE"
 	cd "$WORKSPACE_DIR"
 
 	# "Export" a cleaned copy to a temp directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,11 @@ if [[ -z "$ASSETS_DIR" ]]; then
 fi
 echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 
+if [[ -z "$WORKSPACE_DIR" ]]; then
+	WORKSPACE_DIR=$GITHUB_WORKSPACE
+fi
+echo "ℹ︎ $WORKSPACE_DIR is $GITHUB_WORKSPACE"
+
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="/github/svn-${SLUG}"
 
@@ -62,11 +67,11 @@ if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
 	echo "ℹ︎ Using .distignore"
 	# Copy from current branch to /trunk, excluding dotorg assets
 	# The --delete flag will delete anything in destination that no longer exists in source
-	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
+	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$WORKSPACE_DIR/" trunk/ --delete --delete-excluded
 else
 	echo "ℹ︎ Using .gitattributes"
 
-	cd "$GITHUB_WORKSPACE"
+	cd "$WORKSPACE_DIR"
 
 	# "Export" a cleaned copy to a temp directory
 	TMP_DIR="/github/archivetmp"
@@ -84,7 +89,7 @@ else
 		/.github export-ignore
 		EOL
 
-		# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
+		# Ensure we are in the $WORKSPACE_DIR directory, just in case
 		# The .gitattributes file has to be committed to be used
 		# Just don't push it to the origin repo :)
 		git add .gitattributes && git commit -m "Add .gitattributes file"


### PR DESCRIPTION
## Requirements

Addresses #16 by re-approaching #30

### Description of the Change

#16 is about having the code to push to the plugin repository in a separate folder to the git repo root.

This is a pattern I am familiar with through https://github.com/Lewiscowles1986/WordPressSVGPlugin

WordPress does not use or support Composer, so I ship my plugin with it's own autoloader and vendor folder.

I Like to keep the code separate to the vendor folder.

Also guards (WiP) the image subversion attribute change to cut down chatty logs

### Alternate Designs

1. I could approach by asking myself and a number of other plugin authors to re-approach their repository design.
    * Means they would be shipping tests
    * Means any files in a repo, for it's release are shipped with plugins (I don't feel like this is ideal)
2. The PR at #30 is a slight variation of this one, where .wordpress-org (default asset folder), .gitattributes or it's analogue file are not part of the repo root either.
    * This seemed to be doing more than we had to.
    * This could result in confusion browsing repositories.
    * I can see why not all source code and files should be deployed.
    * I cannot see why moving all the conventional paths makes sense, and the concatenation of paths I could see causing problems

### Benefits

* Less files to compress, push via SVN
* Developer freedom to support intricate build processes (Gutenberg plugins...)
* Simple environment variable

### Possible Drawbacks

Technical complexity. A Thing is less easy to think about like this. People may enter paths that do not exist (possible future iteration).

### Verification Process

I have not verified this, although I would be happy to think about how to do that. It's currently holding back a PR 😂 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### I would like help with these two if it is available... (I appeased shellcheck 😉 )

- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

https://github.com/Lewiscowles1986/WordPressSVGPlugin/runs/1294128965 shows this as working.

### Applicable Issues

#16 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

* Added new ENV arg to re-target the plugin-directory base path `WORKSPACE_DIR`
