### PR TITLE
Added mime type change for .gif files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
 ## [Unreleased] - TBD
+### Added
+- Added mime type change to `image/gif` for `.gif` files.
 
 ## [2.0.0] - 2021-08-16
 This is now a composite Action, meaning that it runs directly on the GitHub Actions runner rather than spinning up its own container and is significantly faster.

--- a/deploy.sh
+++ b/deploy.sh
@@ -117,6 +117,7 @@ svn cp "trunk" "tags/$VERSION"
 # https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
 svn propset svn:mime-type image/png assets/*.png || true
 svn propset svn:mime-type image/jpeg assets/*.jpg || true
+svn propset svn:mime-type image/gif assets/*.gif || true
 
 svn status
 


### PR DESCRIPTION
### Description of the Change
Screenshots can be `.gif` files. These are useful for showing the interaction the user can expect. The mime-type of `.gif` files is not updated. This PR adds that.

### Alternate Designs

None. I can do it by hand every time 😄 

### Benefits

`.gif` files in the assets-folder will automatically have the correct mime type, and this will prevent people from downloading the file, instead of viewing it in the browser.

### Possible Drawbacks

If you really want people to download the `.gif` files, this would prevent that. I think the chances of this are slim to non-existent.

### Verification Process

There is really nothing to verify; other than that you can actually use `.gif` as a screenshot. Take a look at [our screenshot section](https://wordpress.org/plugins/gf-sort-export/#screenshots) for an example.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

- #75 

### Changelog Entry
```md
### Added
- Added mime type change to `image/gif` for `.gif` files.
```
