### PR TITLE
Set mime-type for SVG assets

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -117,6 +117,7 @@ svn cp "trunk" "tags/$VERSION"
 # https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
 svn propset svn:mime-type image/png assets/*.png || true
 svn propset svn:mime-type image/jpeg assets/*.jpg || true
+svn propset svn:mime-type image/svg+xml assets/*.svg || true
 
 svn status
 


### PR DESCRIPTION
### Description of the Change

This change sets files with a SVG extension in the `assets/` directory to `image/svg+xml` so SVG format plugin icons are rendered correctly.

### Benefits

Ensures SVG images have the correct mime type.

### Possible Drawbacks

Unknown

### Verification Process

This is based on running the same manual command as has been added to `deploy.sh`

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

[10up/action-wordpress-plugin-asset-update#31](https://github.com/10up/action-wordpress-plugin-asset-update/issues/31)

### Changelog Entry

Added setting of SVG format assets to image/svg+xml
