### PR TITLE
Fix: Repo with no images gets SVN error

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -115,9 +115,18 @@ svn cp "trunk" "tags/$VERSION"
 
 # Fix screenshots getting force downloaded when clicking them
 # https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
-svn propset svn:mime-type image/png assets/*.png || true
-svn propset svn:mime-type image/jpeg assets/*.jpg || true
-svn propset svn:mime-type image/gif assets/*.gif || true
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.png" -print -quit)"; then
+    svn propset svn:mime-type "image/png" "$SVN_DIR/assets/*.png" || true
+fi
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.jpg" -print -quit)"; then
+    svn propset svn:mime-type "image/jpeg" "$SVN_DIR/assets/*.jpg" || true
+fi
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.gif" -print -quit)"; then
+    svn propset svn:mime-type "image/gif" "$SVN_DIR/assets/*.gif" || true
+fi
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.svg" -print -quit)"; then
+    svn propset svn:mime-type "image/svg+xml" "$SVN_DIR/assets/*.svg" || true
+fi
 
 svn status
 


### PR DESCRIPTION
Fixes #57

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Guards image svn commands using glob check for images

### Alternate Designs

Nothing else was considered

### Benefits

No errors for plugins without the media. Allowing more basic and hobbyist devs to dip a toe in and gradually enhance plugin repo's.

### Possible Drawbacks

I Hope not any from a technical standpoint.

### Verification Process

I Used this code on one of my own repo's/

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#57 

### Changelog Entry

### Changed

* Image upload no longer makes action fail if no images are in the repository being submitted.