### PR TITLE
Fix: Deploy a specific directory within repository 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 * `SLUG` - defaults to the repository name, customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `VERSION` - defaults to the tag name; do not recommend setting this except for testing purposes.
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
+* `BUILD_DIR` - defaults to `false`. Set this flag to the directory where you build your plugins files into, then the action will copy and deploy files from that directory. Both absolute and relative paths are supported. The relative path if provided will be concatenated with the repository root directory. All files and folders in the build directory will be deployed, `.disignore` or `.gitattributes` will be ignored.
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,6 +38,13 @@ if [[ -z "$ASSETS_DIR" ]]; then
 fi
 echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 
+if [[ -z "$BUILD_DIR" ]]; then
+	BUILD_DIR=false
+elif [[ $BUILD_DIR != /* ]]; then 
+	BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}"
+fi
+echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
+
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="${HOME}/svn-${SLUG}"
 
@@ -49,47 +56,53 @@ cd "$SVN_DIR"
 svn update --set-depth infinity assets
 svn update --set-depth infinity trunk
 
-echo "➤ Copying files..."
-if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
-	echo "ℹ︎ Using .distignore"
-	# Copy from current branch to /trunk, excluding dotorg assets
-	# The --delete flag will delete anything in destination that no longer exists in source
-	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
-else
-	echo "ℹ︎ Using .gitattributes"
 
-	cd "$GITHUB_WORKSPACE"
+if [[ "$BUILD_DIR" = false ]]; then
+	echo "➤ Copying files..."
+	if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
+		echo "ℹ︎ Using .distignore"
+		# Copy from current branch to /trunk, excluding dotorg assets
+		# The --delete flag will delete anything in destination that no longer exists in source
+		rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
+	else
+		echo "ℹ︎ Using .gitattributes"
 
-	# "Export" a cleaned copy to a temp directory
-	TMP_DIR="${HOME}/archivetmp"
-	mkdir "$TMP_DIR"
+		cd "$GITHUB_WORKSPACE"
 
-	git config --global user.email "10upbot+github@10up.com"
-	git config --global user.name "10upbot on GitHub"
+		# "Export" a cleaned copy to a temp directory
+		TMP_DIR="${HOME}/archivetmp"
+		mkdir "$TMP_DIR"
 
-	# If there's no .gitattributes file, write a default one into place
-	if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
-		cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
-		/$ASSETS_DIR export-ignore
-		/.gitattributes export-ignore
-		/.gitignore export-ignore
-		/.github export-ignore
-		EOL
+		git config --global user.email "10upbot+github@10up.com"
+		git config --global user.name "10upbot on GitHub"
 
-		# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
-		# The .gitattributes file has to be committed to be used
-		# Just don't push it to the origin repo :)
-		git add .gitattributes && git commit -m "Add .gitattributes file"
+		# If there's no .gitattributes file, write a default one into place
+		if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
+			cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
+			/$ASSETS_DIR export-ignore
+			/.gitattributes export-ignore
+			/.gitignore export-ignore
+			/.github export-ignore
+			EOL
+
+			# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
+			# The .gitattributes file has to be committed to be used
+			# Just don't push it to the origin repo :)
+			git add .gitattributes && git commit -m "Add .gitattributes file"
+		fi
+
+		# This will exclude everything in the .gitattributes file with the export-ignore flag
+		git archive HEAD | tar x --directory="$TMP_DIR"
+
+		cd "$SVN_DIR"
+
+		# Copy from clean copy to /trunk, excluding dotorg assets
+		# The --delete flag will delete anything in destination that no longer exists in source
+		rsync -rc "$TMP_DIR/" trunk/ --delete --delete-excluded
 	fi
-
-	# This will exclude everything in the .gitattributes file with the export-ignore flag
-	git archive HEAD | tar x --directory="$TMP_DIR"
-
-	cd "$SVN_DIR"
-
-	# Copy from clean copy to /trunk, excluding dotorg assets
-	# The --delete flag will delete anything in destination that no longer exists in source
-	rsync -rc "$TMP_DIR/" trunk/ --delete --delete-excluded
+else
+	echo "ℹ︎ Copying files from build directory..."
+	rsync -rc "$BUILD_DIR" trunk/ --delete --delete-excluded
 fi
 
 # Copy dotorg assets to /assets

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,7 +41,7 @@ echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 if [[ -z "$BUILD_DIR" ]]; then
 	BUILD_DIR=false
 elif [[ $BUILD_DIR != /* ]]; then 
-	BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}"
+	BUILD_DIR="${GITHUB_WORKSPACE%/}/${BUILD_DIR}"
 fi
 echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,12 +38,18 @@ if [[ -z "$ASSETS_DIR" ]]; then
 fi
 echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 
-if [[ -z "$BUILD_DIR" ]]; then
+if [[ -z "$BUILD_DIR" ]] || [[ $BUILD_DIR == "./" ]]; then
 	BUILD_DIR=false
-elif [[ $BUILD_DIR != /* ]]; then 
-	BUILD_DIR="${GITHUB_WORKSPACE%/}/${BUILD_DIR}"
+elif [[ $BUILD_DIR == ./* ]]; then 
+	BUILD_DIR=${BUILD_DIR:2}
 fi
-echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
+
+if [[ "$BUILD_DIR" != false ]]; then
+	if [[ $BUILD_DIR != /* ]]; then 
+		BUILD_DIR="${GITHUB_WORKSPACE%/}/${BUILD_DIR}"
+	fi
+	echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
+fi
 
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="${HOME}/svn-${SLUG}"


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR supports deploying plugin files from a custom build directory by introducing a new flag `BUILD_DIR`:

- By default, `$BUILD_DIR` is set to `false`.
- If an absolute path was given, `$BUILD_DIR` will keep using that path.
- If a relative path was given, `$BUILD_DIR` will be concatenated with `$GITHUB_WORKSPACE`.

All files in the `BUILD_DIR` will be copied and deployed, and because those files are generated by a build command, there is no need to use `.disignore` or `.gitattribute` here.

Note: The asset files are still copied from the repository root directory.
<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #16

### Alternate Designs
#30 #56
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

This requires manual verification by deploying a real plugin using this branch.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - Custom build directory support.

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @dinhtungdu @mauryaratan
