### PR TITLE
Fix: custom build dir path

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -46,7 +46,7 @@ fi
 
 if [[ "$BUILD_DIR" != false ]]; then
 	if [[ $BUILD_DIR != /* ]]; then 
-		BUILD_DIR="${GITHUB_WORKSPACE%/}/${BUILD_DIR}"
+		BUILD_DIR="${GITHUB_WORKSPACE%/}/${BUILD_DIR%/}"
 	fi
 	echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
 fi
@@ -108,7 +108,7 @@ if [[ "$BUILD_DIR" = false ]]; then
 	fi
 else
 	echo "ℹ︎ Copying files from build directory..."
-	rsync -rc "$BUILD_DIR" trunk/ --delete --delete-excluded
+	rsync -rc "$BUILD_DIR/" trunk/ --delete --delete-excluded
 fi
 
 # Copy dotorg assets to /assets


### PR DESCRIPTION
It turned out that `rsync` needs a full directory path with a trailing slash to copy nested files and directories. Without trailing slash, `rsync` will copy the directory itself.

This PR fix that issue by forcing the `BUILD_DIR` variable to **not** has the trailing slash, then add a trailing slash to it when it's used for `rsync`.

## How to test this PR

See https://github.com/dinhtungdu/command-palette/runs/5584834600. I had to add the slash to the `BUILD_DIR` in the workflow file to make the action deploy changes from the custom build directory.

https://github.com/dinhtungdu/command-palette/blob/ca3f6d972e299007f7c1a0ab4c4e1befb222e00d/.github/workflows/deploy.yml#L16-L24