### PR TITLE
Provide option to pick version from Stable tag in README.TXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.
+* `version-stable-tag` -  Use version from first matching `Stable tag` (case insensitive) in README.TXT (case insensitive) instead of release tag. Defaults to false.
 
 ### Outputs
 * `zip-path` - The path to the ZIP file generated if `generate-zip` is set to `true`. Fully qualified including the filename, intended for use in further workflow steps such as uploading release assets.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   generate-zip:
     description: 'Generate package zip file?'
     default: false
+  version-stable-tag:
+    description: 'Use README.TXT (case insensitive) stable tag version instead?'
+    default: false
 outputs:
   zip-path:
     description: 'Path to zip file'
@@ -18,5 +21,6 @@ runs:
     - id: deploy
       env:
         INPUT_GENERATE_ZIP: ${{ inputs.generate-zip }}
+        VERSION_STABLE_TAG: ${{ inputs.version-stable-tag }}
       run: ${{ github.action_path }}/deploy.sh
       shell: bash

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,12 @@ echo "ℹ︎ SLUG is $SLUG"
 
 # Does it even make sense for VERSION to be editable in a workflow definition?
 if [[ -z "$VERSION" ]]; then
-	VERSION="${GITHUB_REF#refs/tags/}"
+
+	if $VERSION_STABLE_TAG; then
+		VERSION=$(find . -iname "README.TXT" -exec grep -oiP -m 1 'stable\s+tag\s*:\s\K.*' {} \;)
+	else
+		VERSION="${GITHUB_REF#refs/tags/}"
+	fi
 	VERSION="${VERSION#v}"
 fi
 echo "ℹ︎ VERSION is $VERSION"


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Not all WordPress plugins make use of Github release tags (yes, release tags can be created through a workflow), which adds an extra unnecessary step. Having an option to select the method to obtain the release tag would to a certain extent allow a degree of freedom to switch between tags and use of preferred release method whilst directly controlling the version released to WordPress.

<!-- Enter any applicable Issues here. Example: -->
Partially addresses #85 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

Alternatively one can manually create a release (maybe use a workflow) to be picked by this workflow, but this adds another layer and steps to the release process.

Another option though not documented would be to set the version environment variable the same way SVN_USERNAME and SVN_PASSWORD is set using a bash script to extract the version number

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Those relying on tags would wish they had this feature earlier ;), on a more serious note, I could not think of one but I will make it known that whilst looking for a workflow to push to WordPress (had a local script before [Gist extract WordPress Plugin](https://gist.github.com/richard-muvirimi/82f279bfc97781d2bb24185d49bc6332)) I was instantly deterred by the forced use of release tags.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
- 
Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I copied a README.TXT file into the directory and placed the stable tag with different capitalizations in random places in the document. then in a different `dot sh` file, I extracted and echoed the first version number which is the one read by WordPress.

```sh
VERSION=$(find . -iname "README.TXT" -exec grep -oiP -m 1 'stable\s+tag\s*:\s\K.*' {} \;)
echo ${VERSION#v}
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props #85 felt close to the problem this PR addresses
