### PR TITLE
Allow use of last git commit message or a custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.
-* `commit-message` -  Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else a resolvable command/text. Defaults to false.
+* `commit-message` -  Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else any text. Defaults to false.
 
 ### Outputs
 * `zip-path` - The path to the ZIP file generated if `generate-zip` is set to `true`. Fully qualified including the filename, intended for use in further workflow steps such as uploading release assets.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.
-* `use-commit-message` -  Use the latest git commit message as the svn commit message, otherwise use "Update to version $VERSION from GitHub". Defaults to false.
+* `use-commit-message` - Accepts either a boolean or text value, Defaults to false.
+  - `true` : Will use the last Git Commit message.
+  - `false` : Will use "Update to version $VERSION from GitHub"
+  - `text` : Any text value to be used as the commit message. Useful for when you want to dynamically generate the commit message.
 
 ### Outputs
 * `zip-path` - The path to the ZIP file generated if `generate-zip` is set to `true`. Fully qualified including the filename, intended for use in further workflow steps such as uploading release assets.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.
-* `use-commit-message` -  Use git the latest git commit message as the svn commit message, otherwise use "Update to version $VERSION from GitHub". Defaults to false.
+* `use-commit-message` -  Use the latest git commit message as the svn commit message, otherwise use "Update to version $VERSION from GitHub". Defaults to false.
 
 ### Outputs
 * `zip-path` - The path to the ZIP file generated if `generate-zip` is set to `true`. Fully qualified including the filename, intended for use in further workflow steps such as uploading release assets.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.
-* `commit-message` -  Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else any text. Defaults to false.
+* `use-commit-message` -  Use git the latest git commit message as the svn commit message, otherwise use "Update to version $VERSION from GitHub". Defaults to false.
 
 ### Outputs
 * `zip-path` - The path to the ZIP file generated if `generate-zip` is set to `true`. Fully qualified including the filename, intended for use in further workflow steps such as uploading release assets.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Inputs
 * `generate-zip` - Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps. Defaults to false.
+* `commit-message` -  Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else a resolvable command/text. Defaults to false.
 
 ### Outputs
 * `zip-path` - The path to the ZIP file generated if `generate-zip` is set to `true`. Fully qualified including the filename, intended for use in further workflow steps such as uploading release assets.

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Generate package zip file?'
     default: false
   commit-message:
-    description: 'Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else a resolvable command/text.'
+    description: 'Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else any text.'
     default: false
 outputs:
   zip-path:

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   generate-zip:
     description: 'Generate package zip file?'
     default: false
+  commit-message:
+    description: 'Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else a resolvable command/text.'
+    default: false
 outputs:
   zip-path:
     description: 'Path to zip file'
@@ -18,5 +21,6 @@ runs:
     - id: deploy
       env:
         INPUT_GENERATE_ZIP: ${{ inputs.generate-zip }}
+        INPUT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
       run: ${{ github.action_path }}/deploy.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,6 @@ runs:
     - id: deploy
       env:
         INPUT_GENERATE_ZIP: ${{ inputs.generate-zip }}
-        INPUT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        INPUT_USE_COMMIT_MESSAGE: ${{ inputs.use-commit-message }}
       run: ${{ github.action_path }}/deploy.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   generate-zip:
     description: 'Generate package zip file?'
     default: false
-  commit-message:
+  use-commit-message:
     description: 'Use git last commit message if true, or "Update to version $VERSION from GitHub" if false else any text.'
     default: false
 outputs:

--- a/deploy.sh
+++ b/deploy.sh
@@ -150,7 +150,7 @@ fi
 svn status
 
 echo "➤ Committing files..."
-if [[ "$INPUT_COMMIT_MESSAGE" != false ]]; then
+if [[ "$INPUT_USE_COMMIT_MESSAGE" != false ]]; then
 	if [[ "$INPUT_COMMIT_MESSAGE" = true ]]; then
 		#.git DIR still in place, so we should be able to retrieve the last message
 		MESSAGE=$(git -C "$GITHUB_WORKSPACE" log -1 --format=%s)

--- a/deploy.sh
+++ b/deploy.sh
@@ -150,17 +150,20 @@ fi
 svn status
 
 echo "➤ Committing files..."
-if [[ "$INPUT_USE_COMMIT_MESSAGE" != false ]]; then
-	if [[ "$INPUT_COMMIT_MESSAGE" = true ]]; then
+case $INPUT_USE_COMMIT_MESSAGE in
+	true)
 		#.git DIR still in place, so we should be able to retrieve the last message
 		MESSAGE=$(git -C "$GITHUB_WORKSPACE" log -1 --format=%s)
-	else
+		;;
+	false)
+		MESSAGE="Update to version $VERSION from GitHub"
+		;;
+	*)
 		#provided commit message
-		MESSAGE=$INPUT_COMMIT_MESSAGE
-	fi
-else
-	MESSAGE="Update to version $VERSION from GitHub"
-fi
+		MESSAGE=$INPUT_USE_COMMIT_MESSAGE
+		;;
+esac
+
 svn commit -m "$MESSAGE" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
 if $INPUT_GENERATE_ZIP; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -155,8 +155,8 @@ if [[ "$INPUT_COMMIT_MESSAGE" != false ]]; then
 		#.git DIR still in place, so we should be able to retrieve the last message
 		MESSAGE=$(git -C "$GITHUB_WORKSPACE" log -1 --format=%s)
 	else
-		#resolve message, if required
-		MESSAGE=$($INPUT_COMMIT_MESSAGE)
+		#provided commit message
+		MESSAGE=$INPUT_COMMIT_MESSAGE
 	fi
 else
 	MESSAGE="Update to version $VERSION from GitHub"

--- a/deploy.sh
+++ b/deploy.sh
@@ -150,7 +150,18 @@ fi
 svn status
 
 echo "➤ Committing files..."
-svn commit -m "Update to version $VERSION from GitHub" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+if [[ "$INPUT_COMMIT_MESSAGE" != false ]]; then
+	if [[ "$INPUT_COMMIT_MESSAGE" = true ]]; then
+		#.git DIR still in place, so we should be able to retrieve the last message
+		MESSAGE=$(git -C "$GITHUB_WORKSPACE" log -1 --format=%s)
+	else
+		#resolve message, if required
+		MESSAGE=$($INPUT_COMMIT_MESSAGE)
+	fi
+else
+	MESSAGE="Update to version $VERSION from GitHub"
+fi
+svn commit -m "$MESSAGE" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
 if $INPUT_GENERATE_ZIP; then
   echo "Generating zip file..."


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Allows customization of svn commit message using the last git message or any other text, defaulting to the commit message "Update to version $VERSION from GitHub". I understand not everyone wants the same message across different plugins, becomes pointless to even have the option to set the message on svn's part.

<!-- Enter any applicable Issues here. Example: -->
Partially addresses #18 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

Not sure there was any other alternative besides forking the repository and changing to a message one desires, and in the process set yourself up to have to maintain the forked code

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Different messages for each commit (Commit messages can be different?: Mind Blown) ;), On a serious note, commit messages should be different across releases so that it's easier to identify what changed.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I created a `dot sh` file that I ran to test all the possible paths (pasted below)

```sh
INPUT_COMMIT_MESSAGE="Custom commit message"

if [[ "$INPUT_COMMIT_MESSAGE" != false ]]; then
	if [[ "$INPUT_COMMIT_MESSAGE" = true ]]; then
		#.git DIR still in place, so we should be able to retrieve the last message
		MESSAGE=$(git -C "$GITHUB_WORKSPACE" log -1 --format=%s)
	else
		#provided commit message
		MESSAGE=$INPUT_COMMIT_MESSAGE
	fi
else
	MESSAGE="Update to version $VERSION from GitHub"
fi

echo $MESSAGE
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Partially addresses #18 
