### PR TITLE
Add release workflow

### DIFF
--- a/.github/release-pull-request-template.md
+++ b/.github/release-pull-request-template.md
@@ -1,0 +1,11 @@
+- [x] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
+- [ ] Changelog: Add/update the changelog in `CHANGELOG.md`. 
+- [ ] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
+- [ ] Readme updates: Make any other readme changes as necessary in `README.md`.
+- [ ] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
+- [ ] Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
+- [ ] Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-deploy/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-deploy/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-deploy/releases).
+- [ ] Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-deploy) correctly.
+- [ ] Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-deploy/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
+- [ ] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+- [ ]0`, `X+- [ ]0.0` or `Future Release`.
+- [ ] Celebrate shipping!

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -1,0 +1,22 @@
+name: Release Pull Request Automation
+
+on:
+  create:
+jobs:
+  release-pull-request-automation:
+    if: ${{ github.event.ref_type == 'branch' && contains( github.ref, 'release/' ) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Generate title
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo $BRANCH
+          VERSION=${BRANCH#'release/'}
+          echo ::set-output name=result::"Release: ${VERSION}"
+        id: title
+      - name: Create Pull Request
+        run: gh pr create --title "${{ steps.title.outputs.result }}" --body-file ./.github/release-pull-request-template.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,6 @@ This repository currently uses the `develop` branch to reflect active work and `
 
 ## Release instructions
 
-1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-1. Changelog: Add/update the changelog in `CHANGELOG.md`. 
-1. Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
-1. Readme updates: Make any other readme changes as necessary in `README.md`.
-1. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then merge `develop` into `stable` (`git checkout stable && git merge --no-ff develop`).
-1. Push: Push your stable branch to GitHub (e.g. `git push origin stable`).
-1. Release: Create a [new release](https://github.com/10up/action-wordpress-plugin-deploy/releases/new), naming the tag and the release with the new version number, and targeting the `stable` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/action-wordpress-plugin-deploy/milestones/#?closed=1).  The release should now appear under [releases](https://github.com/10up/action-wordpress-plugin-deploy/releases).
-1. Ensure the release [appears in the GitHub Marketplace](https://github.com/marketplace/actions/wordpress-plugin-deploy) correctly.
-1. Close milestone: Edit the [milestone](https://github.com/10up/action-wordpress-plugin-deploy/milestones/) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description field`), then close the milestone.
-1. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
-1. Celebrate shipping!
+A new release pull requestwill be created automatically once a branch named `release/X.Y.Z` is pushed to GitHub.
+
+The step by step release instructions can be found in [.github/release-pull-request-template.md](.github/release-pull-request-template.md).


### PR DESCRIPTION
This PR mimics the work on https://github.com/10up/action-wordpress-plugin-asset-update/pull/45 to add the release automation for this deploy action.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dinhtungdu