### PR TITLE
fix: Replace deprecated `set-output` command

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
           BRANCH=${GITHUB_REF##*/}
           echo $BRANCH
           VERSION=${BRANCH#'release/'}
-          echo ::set-output name=result::"Release: ${VERSION}"
+          echo "result=Release: ${VERSION}" >> "${GITHUB_OUTPUT}"
         id: title
       - name: Create Pull Request
         run: gh pr create --title "${{ steps.title.outputs.result }}" --body-file ./.github/release-pull-request-template.md

--- a/deploy.sh
+++ b/deploy.sh
@@ -159,7 +159,7 @@ if $INPUT_GENERATE_ZIP; then
   echo "Generating zip file..."
   cd "$SVN_DIR/trunk" || exit
   zip -r "${GITHUB_WORKSPACE}/${SLUG}.zip" .
-  echo "::set-output name=zip-path::${GITHUB_WORKSPACE}/${SLUG}.zip"
+  echo "zip-path=${GITHUB_WORKSPACE}/${SLUG}.zip" >> "${GITHUB_OUTPUT}"
   echo "✓ Zip file generated!"
 fi
 


### PR DESCRIPTION
### Description of the Change

GitHub has [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the `set-output` and `save-state` commands. This PR updates `deploy.sh` to use the [suggested replacement](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).

### How to test the Change

Do a test deployment with `generate-zip` set to `true`. Observe that the `zip-path` output is present.

### Changelog Entry

Fixed: Replaced the deprecated `set-output` command with redirection to `$GITHUB_OUTPUT`

### Credits

Props @sjinks

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
