### PR TITLE
Add support to automatically update the "Stable tag" and "Tested up to" lines in the readme.txt during deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Optional environment variables
 
-
 * `SLUG` - Defaults to the repository name. This is customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `VERSION` - Defaults to the tag name.  We do not recommend setting this except for testing purposes.
 * `ASSETS_DIR` - Defaults to `.wordpress-org`. This is customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
 * `BUILD_DIR` - Defaults to `false`. Set this flag to the directory where you build your plugins files into, then the action will copy and deploy files from that directory. Both absolute and relative paths are supported. The relative path if provided will be concatenated with the repository root directory. All files and folders in the build directory will be deployed, `.disignore` or `.gitattributes` will be ignored.
-* `SKIP_WP_VERSION` - skips the retrieval of the current WP version from wordpress.org and does not update the readme.txt's "Tested up to" line.
+* `BUMP_WP_TESTED_UP_TO ` - enable the retrieval of the current WP version from wordpress.org and updates the readme.txt's "Tested up to" line.
 * `SKIP_STABLE_TAG` - skips the update of the readme.txt's "Stable tag" line.
 * `SKIP_GIT_COMMIT` - if either the "Test up to line" or "stable tag" line were updated in the readme.txt, then skip committing those changes to the git repo.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 * `SVN_USERNAME`
 * `SVN_PASSWORD`
+* `GIT_USERNAME`
+* `GIT_EMAIL`
 
 [Secrets are set in your repository settings](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets). They cannot be viewed once stored.
 
@@ -96,6 +98,8 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+        GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
         SLUG: my-super-cool-plugin # optional, remove if GitHub repo name matches SVN slug, including capitalization
 ```
 
@@ -125,6 +129,8 @@ jobs:
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+        GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
     - name: Upload release asset
       uses: actions/upload-release-asset@v1
       env:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 ### Optional environment variables
 
+
 * `SLUG` - Defaults to the repository name. This is customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `VERSION` - Defaults to the tag name.  We do not recommend setting this except for testing purposes.
 * `ASSETS_DIR` - Defaults to `.wordpress-org`. This is customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
 * `BUILD_DIR` - Defaults to `false`. Set this flag to the directory where you build your plugins files into, then the action will copy and deploy files from that directory. Both absolute and relative paths are supported. The relative path if provided will be concatenated with the repository root directory. All files and folders in the build directory will be deployed, `.disignore` or `.gitattributes` will be ignored.
+* `SKIP_WP_VERSION` - skips the retrieval of the current WP version from wordpress.org and does not update the readme.txt's "Tested up to" line.
+* `SKIP_STABLE_TAG` - skips the update of the readme.txt's "Stable tag" line.
+* `SKIP_GIT_COMMIT` - if either the "Test up to line" or "stable tag" line were updated in the readme.txt, then skip committing those changes to the git repo.
 
 ### Inputs
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,32 +70,32 @@ if [[ "$BUILD_DIR" != false ]]; then
 fi
 
 echo "i Retrieving current WordPress version from wordpress.org"
-wget http://api.wordpress.org/core/stable-check/1.0/ -O stable.check.txt
+STABLECHECK=`mktemp`
+wget http://api.wordpress.org/core/stable-check/1.0/ -O $STABLECHECK
 
-# Get the second last line of the file.
-tail -n 2 stable.check.txt > stable.tail.txt
-head -n 1 stable.tail.txt > stable.txt
+# Get the "latest" version of WordPress from the file.
+grep '"latest"' stable.check.txt > $STABLECHECK
 
 # Strip out the status.
-sed -i 's/ : "latest"//' stable.txt
+sed -i 's/ : "latest"//' $STABLECHECK
 
 # Get rid of the quotes, tabs, and spaces.
-sed -i 's/["\t\s]//g' stable.txt
+sed -i 's/["\t\s]//g' $STABLECHECK
 
 # Now cut down any 3 part versions, like 6.1.1, to two parts, aka 6.1.
-sed -i 's/\([0-9]*\)\.\([0-9]*\)\.[0-9]*/\1.\2/' stable.txt
+sed -i 's/\([0-9]*\)\.\([0-9]*\)\.[0-9]*/\1.\2/' $STABLECHECK
 
 # Store it in a variable and delete the temp files.
-WP_VERSION=$(<stable.txt)
-rm stable*.txt
-
-echo "i WP_VERSION is $WP_VERSION"
+WP_VERSION=$(<$STABLECHECK)
+rm $STABLECHECK
 
 NEED_COMMIT=""
 
 if [ -z "$WP_VERSION" ]; then
 	echo "e could not retrieve current WordPress version from wordpress.org"
 else
+	echo "i WP_VERSION is $WP_VERSION"
+
 	# Do a grep on the readme.txt file to see if the values already set correctly.
 	README_VERSION=`grep "^Tested up to: $WP_VERSION" ${GITHUB_WORKSPACE}/readme.txt`
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -131,7 +131,7 @@ if [ ! -z "$NEED_COMMIT" ]; then
 	head -n 10 ${GITHUB_WORKSPACE}/readme.txt
 
 	echo "i Committing readme.txt changes to GIT..."
-	git commit -am "Update Tested up to value in readme.txt"
+	git commit -am "Update readme.txt for release $VERSION."
 	git push
 
 	echo "i Updating tag to include changes..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -71,9 +71,7 @@ fi
 
 NEED_COMMIT=""
 
-if [ ! -z "$SKIP_WP_VERSION"]; then
-	echo "i Skipping update of Tested up to value"
-else
+if [ -z "$BUMP_WP_TESTED_UP_TO "]; then
 	echo "i Retrieving current WordPress version from wordpress.org"
 	STABLECHECK=`mktemp`
 	wget http://api.wordpress.org/core/stable-check/1.0/ -O $STABLECHECK


### PR DESCRIPTION
### Description of the Change
Add support to automatically update the "Stable tag" and "Tested up to" lines in the readme.txt during deployment.

Closes #112 

### How to test the Change
Trigger a new deployment.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Added - Support for updating readme.txt "Tested up to" and "Stable tag" automatically as part of the deployment.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @toolstack


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my change.
- [x] All new and existing tests pass.
