### PR TITLE
Update deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,7 @@ if [[ -z "$SLUG" ]]; then
 fi
 echo "ℹ︎ SLUG is $SLUG"
 
-# Does it even make sense for VERSION to be editable in a workflow definition?
+# Allow setting custom version number in advanced workflows
 if [[ -z "$VERSION" ]]; then
 	VERSION="${GITHUB_REF#refs/tags/}"
 	VERSION="${VERSION#v}"


### PR DESCRIPTION
Removed comment regarding unsure feature that enables users to set the version to use for the deployment.

Yes it makes sense to allow for custom setting of the version number in "advanced" workflows. 

Here is an example where I need to set the version number manually by getting the latest plugin version that was uploaded to freemius and then use it as the svn tag version: https://github.com/UVLabs/freemius-wp-org-deploy/blob/main/workflows/upload-to-svn-from-freemius.yml