### PR TITLE
Fix deploy script to not attempt re-publishing the same version of a plugin

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -60,7 +60,7 @@ svn checkout --depth immediates "$SVN_URL" "$SVN_DIR"
 cd "$SVN_DIR"
 svn update --set-depth infinity assets
 svn update --set-depth infinity trunk
-svn update --set-depth infinity tags
+svn update --set-depth immediates tags
 
 # Bail early if the plugin version is already published.
 if [[ -d "tags/$VERSION" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,14 +54,19 @@ fi
 SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="${HOME}/svn-${SLUG}"
 
-# Checkout just trunk and assets for efficiency
-# Tagging will be handled on the SVN level
+# Checkout SVN repository.
 echo "➤ Checking out .org repository..."
 svn checkout --depth immediates "$SVN_URL" "$SVN_DIR"
 cd "$SVN_DIR"
 svn update --set-depth infinity assets
 svn update --set-depth infinity trunk
+svn update --set-depth infinity tags
 
+# Bail early if the plugin version is already published.
+if [[ -d "tags/$VERSION" ]]; then
+	echo "ℹ︎ Version $VERSION of plugin $SLUG was already published";
+	exit
+fi
 
 if [[ "$BUILD_DIR" = false ]]; then
 	echo "➤ Copying files..."


### PR DESCRIPTION
### Description of the Change

I tried this solution in folk repo and here is the result for it. At the moment the [WebP Uploads](http://plugins.svn.wordpress.org/webp-uploads/tags/) is release with version `1.0.0`

- Run the deploy workflow with the slug `webp-uploads` and version `1.0.0`. It will show the message "ℹ︎ Version 1.0.0 of plugin webp-uploads was already published" and skip the script execution without throwing any errors. [Check result here](https://github.com/mukeshpanchal27/performance/actions/runs/4742549334/jobs/8420966951#step:6:74)
- Run the deploy workflow with the slug `webp-uploads` and version `1.0.1`. It will execute all the steps and commit the new version to the SVN repository(For testing i have comment the SVN commit step). [Check result here](https://github.com/mukeshpanchal27/performance/actions/runs/4742553012/jobs/8420973341#step:6:97)


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #123 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @mukeshpanchal27 @joemcgill @felixarntz


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
