### PR TITLE
Set the default `DRY_RUN` to false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   generate-zip:
     description: 'Generate package zip file?'
     default: false
+  dry-run:
+    description: 'Run the deployment process without committing.'
+    default: false
 outputs:
   zip-path:
     description: 'Path to zip file'
@@ -18,5 +21,6 @@ runs:
     - id: deploy
       env:
         INPUT_GENERATE_ZIP: ${{ inputs.generate-zip }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
       run: ${{ github.action_path }}/deploy.sh
       shell: bash


### PR DESCRIPTION
The follow-up changes that were missed in https://github.com/10up/action-wordpress-plugin-deploy/pull/122/#discussion_r1170551586 In this PR, set the default value for `DRY_RUN` to false.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #126

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @mukeshpanchal27, @joemcgill, @felixarntz, @aaemnnosttv, @stephywells


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
