### PR TITLE
Commit files that were built outside of the action

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -96,6 +96,8 @@ if [[ "$BUILD_DIR" = false ]]; then
 		git config --global user.email "10upbot+github@10up.com"
 		git config --global user.name "10upbot on GitHub"
 
+  		git commit -am "Add files that were built outside of the action"
+
 		# If there's no .gitattributes file, write a default one into place
 		if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 			cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL

--- a/deploy.sh
+++ b/deploy.sh
@@ -96,7 +96,10 @@ if [[ "$BUILD_DIR" = false ]]; then
 		git config --global user.email "10upbot+github@10up.com"
 		git config --global user.name "10upbot on GitHub"
 
-  		git commit -am "Add files that were built outside of the action"
+		# Ensure git archive will pick up any changed files in the directory try.
+    		git rm $(git ls-files --deleted)
+  		git add .
+  		git commit -m "Include build step changes"
 
 		# If there's no .gitattributes file, write a default one into place
 		if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -97,7 +97,7 @@ if [[ "$BUILD_DIR" = false ]]; then
 		git config --global user.name "10upbot on GitHub"
 
 		# Ensure git archive will pick up any changed files in the directory try.
-    		git rm $(git ls-files --deleted)
+    		test $(git ls-files --deleted) && git rm $(git ls-files --deleted)
   		git add .
   		git commit -m "Include build step changes"
 


### PR DESCRIPTION
### Description of the Change

When you don't have a BUILD_DIR and a .distignore file, any changes inside the git directory will be ignored when committing to SVN.

This is because we use `git archive HEAD` which builds the archive from the git index, not the directory tree.

A workaround is to manually commit the files in the build step, see https://github.com/GlotPress/GlotPress/pull/1655

Equally well, we can just commit any file changes inside the deploy script since the git changes are only local.

### How to test the Change
1. A Github repository without a `.distignore` file.
2. A build script that adds or modifies files in the git repo (e.g. minfies files).
3. A Github actions script, this is from the README:

```
...
    steps:
    - uses: actions/checkout@master
    - name: Build # Remove or modify this step as needed
      run: |
        npm install
        npm run build
    - name: WordPress Plugin Deploy
      uses: 10up/action-wordpress-plugin-deploy@stable
      env:
        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
```

→ The built or modified files should be included in the svn release.

### Changelog Entry
> Fixed - Bug fix
Ensure built files are included when used without a BUILD_DIR and .distignore file.


### Credits
Props @akirk

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly. -- No changes necessary. This just makes it conform to expected behavior.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.

(I'll update the checklist as soon as the build checks have run)