### PR TITLE
Fixed action failure when the .distignore file is not present in repo.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -114,9 +114,11 @@ if [[ "$BUILD_DIR" = false ]]; then
 		git config --global user.name "10upbot on GitHub"
 
 		# Ensure git archive will pick up any changed files in the directory try.
-    		test $(git ls-files --deleted) && git rm $(git ls-files --deleted)
-  		git add .
-  		git commit -m "Include build step changes"
+		test $(git ls-files --deleted) && git rm $(git ls-files --deleted)
+		if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+			git add .
+			git commit -m "Include build step changes"
+		fi
 
 		# If there's no .gitattributes file, write a default one into place
 		if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then


### PR DESCRIPTION
### Description of the Change
As reported in #136, the action(version 2.2.1) fails when the .distignore file is not present in the repo. 

This issue was introduced in #130. #130 added support for including build files in SVN when the action is used without a BUILD_DIR and .distignore file. In order to achieve this, the `git commit` command was added without checking if there were any untracked files to add and commit. Running git commit on a clean working tree results in a failure with the message (**nothing to commit, working tree clean**).

This PR fixes the issue by adding a condition for untracked files check and only running git commit if untracked files are present.

Closes #136 

### How to test the Change
1. Fork "[Eight Day Week](https://github.com/10up/eight-day-week)"
2. Update the deploy plugin workflow to use action from this fix branch and update workflow to run in a `dry-run`
3. Create a new release on repo. (It will trigger the deploy action)
4. Verify the deploy action, it should run successfully without any failure.

The test I have done on the sample repo: https://github.com/iamdharmesh/GlotPress/actions/runs/6109282764/job/16579976180

### Changelog Entry
> Fixed - Action failure when the .distignore file is not present in repo.


### Credits
Props @iamdharmesh @dkotter 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
