### PR TITLE
Add/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,70 +71,13 @@ If there are files or directories to be excluded from deployment, such as tests 
 
 ## Example Workflow Files
 
-To get started, you will want to copy the contents of one of these examples into `.github/workflows/deploy.yml` and push that to your repository. You are welcome to name the file something else, but it must be in that directory. The usage of `ubuntu-latest` is recommended for compatibility with required dependencies in this Action.
+To get started, you will want to copy the contents of one of [these examples](examples) into `.github/workflows/deploy.yml` and push that to your repository. You are welcome to name the file something else, but it must be in that directory. The usage of `ubuntu-latest` is recommended for compatibility with required dependencies in this Action.
 
-### Deploy on pushing a new tag
+Current set of example workflow files:
 
-```yml
-name: Deploy to WordPress.org
-on:
-  push:
-    tags:
-    - "*"
-jobs:
-  tag:
-    name: New tag
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Build # Remove or modify this step as needed
-      run: |
-        npm install
-        npm run build
-    - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SLUG: my-super-cool-plugin # optional, remove if GitHub repo name matches SVN slug, including capitalization
-```
-
-### Deploy on publishing a new release and attach a ZIP file to the release
-
-```yml
-name: Deploy to WordPress.org
-on:
-  release:
-    types: [published]
-jobs:
-  tag:
-    name: New release
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Build
-      run: |
-        npm install
-        npm run build
-    - name: WordPress Plugin Deploy
-      id: deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
-      with:
-        generate-zip: true
-      env:
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-    - name: Upload release asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ steps.deploy.outputs.zip-path }}
-        asset_name: ${{ github.event.repository.name }}.zip
-        asset_content_type: application/zip
-```
+* [Deploy on publishing a new release and attach a ZIP file to the release](examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml)
+* [Deploy on pushing a new tag](examples/deploy-on-pushing-a-new-tag.yml)
+* [Deploy on pushing a new tag and create release with attached ZIP](examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml)
 
 ## Contributing
 

--- a/examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml
+++ b/examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml
@@ -1,0 +1,32 @@
+name: Deploy to WordPress.org
+on:
+  release:
+    types: [published]
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build
+      run: |
+        npm install
+        npm run build
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ steps.deploy.outputs.zip-path }}
+        asset_name: ${{ github.event.repository.name }}.zip
+        asset_content_type: application/zip

--- a/examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml
+++ b/examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml
@@ -30,3 +30,4 @@ jobs:
         asset_path: ${{ steps.deploy.outputs.zip-path }}
         asset_name: ${{ github.event.repository.name }}.zip
         asset_content_type: application/zip
+        

--- a/examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml
+++ b/examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml
@@ -1,32 +1,100 @@
-name: Deploy to WordPress.org
+# The name of the Github Action that displays in github.com/<username>/<repo>/actions
+name: Deploy to WordPress.org Repository
+
+# Here we can define the events "on" which the action should be triggered.
 on:
+
+  # Since we want to publish new versions of our plugin, we only want this action to
+  # run when publishing a new release.
+  #
+  # The released version of the plugin will then be deployed to the repository.
+  #
+  # This allows us to run and manage plugin releases from a single location.
   release:
-    types: [published]
+
+    # run only when a new release is published, but not when it's classified as a pre-release.
+    types: [released]
+
+# A list of jobs involved in this workflow.
 jobs:
-  tag:
-    name: New release
+
+  # A unique job identifier.
+  #
+  # Github Actions can have multiple jobs and each can be referenced by its name.
+  # However, we only need to run a few steps here and they can be handled in a single job.
+  deploy_to_wp_repository:
+
+    # The proper name for the job being run.
+    name: Deploy to WP.org
+
+    # The environment this job should run on. In the context of WordPress, ubuntu-latest is
+    # pretty typical. Since we are only interacting with git and subversion, Ubuntu is perfect
+    # for this.
+    #
+    # Github does offer other platforms if you need them: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
     runs-on: ubuntu-latest
+
+    # Every job has a specific set of steps that it goes through to do its "work".
+    #
+    # Each step has a two key elements:
+    # • Name
+    # • a "run" command (an arbitrary CLI command to execute) OR a "uses" command that pulls in and executes a 3rd party action.
     steps:
+
+    # Most workflows begin by checking out the repository into the workflow filesystem.
+    #
+    # This is just like cloning a repository except it only checks out the specific commit
+    # the job is executed for. In our case here, the commit that the release is attached to.
     - name: Checkout code
       uses: actions/checkout@v2
+
+    # Optional: If your plugin is using composer dependencies, we want to include them
+    # WITHOUT the dev dependencies.
     - name: Build
       run: |
         npm install
         npm run build
     - name: WordPress Plugin Deploy
+
+      # You can add unique ids to specific steps if you want to reference their output later in the workflow.
+      #
+      # Here, this unique identifier lets us use the output from the action to get the zip-path later.
       id: deploy
+
+      # The use statement lets us pull in the work done by 10up to deploy the plugin to the WordPress repository.
       uses: 10up/action-wordpress-plugin-deploy@stable
+
+      # Steps can also provide arguments, so this configures 10up's action to also generate a zip file.
       with:
         generate-zip: true
+
+      # Steps can also set environment variables which can be configured in the Github settings for the
+      # repository. Here, we are using action secrets SVN_USERNAME, SVN_PASSWORD, and PLUGIN_SLUG which
+      # authenticate with WordPress and lets the action deploy our plugin to the repository.
+      #
+      # To learn more about setting and using secrets with Github Actions, check out: https://docs.github.com/en/actions/security-guides/encrypted-secrets?tool=webui#about-encrypted-secrets
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
+    # After the deploy, we also want to create a zip and upload it to the release on Github. We don't want
+    # users to have to go to the repository to find our plugin :).
     - name: Upload release asset
       uses: actions/upload-release-asset@v1
       env:
+        # Note, this is an exception to action secrets: GH_TOKEN is always available and provides access to
+        # the current repository this action runs in.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       with:
+        # Get the URL for uploading assets to the current release.
         upload_url: ${{ github.event.release.upload_url }}
+
+        # Provide the path to the file generated in the previous step using the output.
         asset_path: ${{ steps.deploy.outputs.zip-path }}
+
+        # Provide what the file should be named when attached to the release (plugin-name.zip)
         asset_name: ${{ github.event.repository.name }}.zip
+
+        # Provide the file type.
         asset_content_type: application/zip

--- a/examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
+++ b/examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
@@ -1,0 +1,30 @@
+name: Deploy and Release Plugin
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build
+      run: |
+        npm install
+        npm run build
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{github.workspace}}/${{ github.event.repository.name }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
+++ b/examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml
@@ -28,3 +28,4 @@ jobs:
         files: ${{github.workspace}}/${{ github.event.repository.name }}.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/examples/deploy-on-pushing-a-new-tag.yml
+++ b/examples/deploy-on-pushing-a-new-tag.yml
@@ -1,0 +1,21 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build # Remove or modify this step as needed
+      run: |
+        npm install
+        npm run build
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: my-super-cool-plugin # optional, remove if GitHub repo name matches SVN slug, including capitalization

--- a/examples/deploy-on-pushing-a-new-tag.yml
+++ b/examples/deploy-on-pushing-a-new-tag.yml
@@ -19,3 +19,4 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: my-super-cool-plugin # optional, remove if GitHub repo name matches SVN slug, including capitalization
+        


### PR DESCRIPTION
### Description of the Change
This PR moves our current set of example workflow files into an `examples` directory, references those from the readme file, and pulls the additional example from #69 into that directory.

Note that this replaces work from #69.

### How to test the Change
Preview with markdown previewer.

### Changelog Entry
> Added - Example workflow files to documentation.

### Credits
Props @alecrust, @helen, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
