### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 * `SLUG` - Defaults to the repository name. This is customizable in case your WordPress repository has a different slug or is capitalized differently.
 * `VERSION` - Defaults to the tag name.  We do not recommend setting this except for testing purposes.
 * `ASSETS_DIR` - Defaults to `.wordpress-org`. This is customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`).
-* `BUILD_DIR` - Defaults to `false`. Set this flag to the directory where you build your plugins files into, then the action will copy and deploy files from that directory. Both absolute and relative paths are supported. The relative path if provided will be concatenated with the repository root directory. All files and folders in the build directory will be deployed, `.disignore` or `.gitattributes` will be ignored.
+* `BUILD_DIR` - Defaults to `false`. Set this flag to the directory where you build your plugins files into, then the action will copy and deploy files from that directory. Both absolute and relative paths are supported. The relative path if provided will be concatenated with the repository root directory. All files and folders in the build directory will be deployed, `.distignore` or `.gitattributes` will be ignored.
 
 ### Inputs
 


### PR DESCRIPTION
### Description of the Change

Hi, first of all, thanks for this awesome action that, I'm using it for every w.org plugin! :)

This is just a small typo fix in the Readme file: ~`.disignore`~ to `.distignore`.

### Changelog Entry

- [x] Fixed - Typo fix in README.md

### Credits
Props @pedro-mendonca


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
