### PR TITLE
Update README to include required actions/checkout@main in workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Current set of example workflow files:
 
 **Note**: The following step is required to check out the repository for use during the workflow run:
 ```
-- uses: actions/checkout@main
+- uses: actions/checkout@v4
 ```
 
 * [Deploy on pushing a new tag and create release with attached ZIP](examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Current set of example workflow files:
 
 * [Deploy on publishing a new release and attach a ZIP file to the release](examples/deploy-on-publishing-a-new-release-and-attach-a-zip-file-to-the-release.yml)
 * [Deploy on pushing a new tag](examples/deploy-on-pushing-a-new-tag.yml)
+
+**Note**: The following step is required to check out the repository for use during the workflow run:
+```
+- uses: actions/checkout@main
+```
+
 * [Deploy on pushing a new tag and create release with attached ZIP](examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml)
 
 ## Contributing


### PR DESCRIPTION
### Description of the Change
This PR addresses an issue in the README's example workflow files where it was unclear that the actions/checkout@main step is required for the GitHub Action to function properly during the deployment process.

Closes #109 

### Changelog Entry
> Added - Documentation update in the README with required actions/checkout@main step for clarity in example workflow

### Credits
Props @frankiebordone 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
