### PR TITLE
Consider not requiring SVN credentials for dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 ### Inputs
 
 * `generate-zip` - Defaults to `false`. Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps.
-* `dry-run` - Defaults to `false`. Set this to `true` if you want to skip the final Subversion commit step (e.g., to debug prior to a non-dry-run commit).
+* `dry-run` - Defaults to `false`. Set this to `true` if you want to skip the final Subversion commit step (e.g., to debug prior to a non-dry-run commit). `dry-run` - `true` Doesn't require SVN secret.
 
 ### Outputs
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,6 +40,14 @@ fi
 # Check if it's a dry-run first
 if $INPUT_DRY_RUN; then
   echo "ℹ︎ Dry run: No files will be committed to Subversion."
+  
+  if [[ -z "$SVN_USERNAME" ]]; then
+    echo "Warning: SVN_USERNAME is missing. The commit will fail if you attempt a real run."
+  fi
+
+  if [[ -z "$SVN_PASSWORD" ]]; then
+    echo "Warning: SVN_PASSWORD is missing. The commit will fail if you attempt a real run."
+  fi
 else
   # If it's not a dry-run, check for SVN credentials
   if [[ -z "$SVN_USERNAME" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,18 +36,21 @@ fi
 # IMPORTANT: while secrets are encrypted and not viewable in the GitHub UI,
 # they are by necessity provided as plaintext in the context of the Action,
 # so do not echo or use debug mode unless you want your secrets exposed!
-if [[ -z "$SVN_USERNAME" ]]; then
-	echo "Set the SVN_USERNAME secret"
-	exit 1
-fi
 
-if [[ -z "$SVN_PASSWORD" ]]; then
-	echo "Set the SVN_PASSWORD secret"
-	exit 1
-fi
-
+# Check if it's a dry-run first
 if $INPUT_DRY_RUN; then
-	echo "ℹ︎ Dry run: No files will be committed to Subversion."
+  echo "ℹ︎ Dry run: No files will be committed to Subversion."
+else
+  # If it's not a dry-run, check for SVN credentials
+  if [[ -z "$SVN_USERNAME" ]]; then
+    echo "Set the SVN_USERNAME secret"
+    exit 1
+  fi
+
+  if [[ -z "$SVN_PASSWORD" ]]; then
+    echo "Set the SVN_PASSWORD secret"
+    exit 1
+  fi
 fi
 
 # Allow some ENV variables to be customized


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### SVN credentials are only required when the script is performing a real deployment (not during dry-run).
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #149 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

   - Set `dry-run: true`.
   - Run the script with missing SVN credentials (`SVN_USERNAME` and `SVN_PASSWORD`).
   - Ensure the script does not exit and displays a warning message indicating that the credentials are missing but continues the dry-run.
   

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @aaemnnosttv  ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
