### PR TITLE
Add trunk-only deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Current set of example workflow files:
 ```
 
 * [Deploy on pushing a new tag and create release with attached ZIP](examples/deploy-on-pushing-a-new-tag-and-create-release-with-attached-zip.yml)
+* [Deploy to both trunk and tag during release, and only to trunk during commits to the main branch](examples/deploy-on-tag-and-branch.yml)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 
 * `generate-zip` - Defaults to `false`. Generate a ZIP file from the SVN `trunk` directory. Outputs a `zip-path` variable for use in further workflow steps.
 * `dry-run` - Defaults to `false`. Set this to `true` if you want to skip the final Subversion commit step (e.g., to debug prior to a non-dry-run commit). `dry-run` - `true` Doesn't require SVN secret.
+* `trunk-only` - Defaults to `false`. When set to `true`, deploys only to the WordPress.org `trunk` and `assets` directories without creating a new tag in the plugin repository. Useful for updating `readme.txt` (for example, the `Tested up to` value) or assets between full releases.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   dry-run:
     description: 'Run the deployment process without committing.'
     default: false
+  trunk-only:
+    description: 'Deploy only to trunk/assets without creating a new tag in the WordPress.org plugin repository.'
+    default: false
 outputs:
   zip-path:
     description: 'Path to zip file'
@@ -22,5 +25,6 @@ runs:
       env:
         INPUT_GENERATE_ZIP: ${{ inputs.generate-zip }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_TRUNK_ONLY: ${{ inputs.trunk-only }}
       run: ${{ github.action_path }}/deploy.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Run the deployment process without committing.'
     default: false
   trunk-only:
-    description: 'Deploy only to trunk/assets without creating a new tag in the WordPress.org plugin repository.'
+    description: 'Deploy only to trunk/assets without creating a new tag.'
     default: false
 outputs:
   zip-path:

--- a/deploy.sh
+++ b/deploy.sh
@@ -80,6 +80,11 @@ else
 	echo "ℹ︎ VERSION is not set; trunk-only deployment assumed unless overridden."
 fi
 
+# Cast to empty string when not set for easier -n checks.
+if [[ "$INPUT_TRUNK_ONLY" != "true" ]]; then
+	INPUT_TRUNK_ONLY=""
+fi
+
 if [[ -z "$ASSETS_DIR" ]]; then
 	ASSETS_DIR=".wordpress-org"
 fi
@@ -126,7 +131,7 @@ generate_zip() {
 # Bail early if the plugin version is already published.
 # Only relevant when we are creating a new tag, not for
 # trunk-only deployments where VERSION may be empty.
-if [[ ! $INPUT_TRUNK_ONLY && -n "$VERSION" && -d "tags/$VERSION" ]] then
+if [[ -n "$VERSION" && -d "tags/$VERSION" && -z "$INPUT_TRUNK_ONLY" ]]; then
 	echo "ℹ︎ Version $VERSION of plugin $SLUG was already published";
 
 	generate_zip
@@ -213,7 +218,7 @@ svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
 
 # Copy tag locally to make this a single commit when not
 # doing a trunk-only deployment.
-if [[ -n "$VERSION" && ! $INPUT_TRUNK_ONLY ]] then
+if [[ -n "$VERSION" && -z "$INPUT_TRUNK_ONLY" ]]; then
 	echo "➤ Copying tag..."
 	svn cp trunk "tags/$VERSION"
 fi
@@ -244,7 +249,7 @@ else
   echo "➤ Committing files..."
 
   COMMIT_MSG="Update from GitHub"
-  if [[ -n "$VERSION" && ! $INPUT_TRUNK_ONLY ]] then
+  if [[ -n "$VERSION" && -z "$INPUT_TRUNK_ONLY" ]]; then
     COMMIT_MSG="Update to version $VERSION from GitHub"
   fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -220,7 +220,7 @@ svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
 # doing a trunk-only deployment.
 if [[ -n "$VERSION" && -z "$INPUT_TRUNK_ONLY" ]]; then
 	echo "➤ Copying tag..."
-	svn cp trunk "tags/$VERSION"
+	svn cp "trunk" "tags/$VERSION"
 fi
 
 # Fix screenshots getting force downloaded when clicking them

--- a/deploy.sh
+++ b/deploy.sh
@@ -67,12 +67,18 @@ if [[ -z "$SLUG" ]]; then
 fi
 echo "ℹ︎ SLUG is $SLUG"
 
-# Allow setting custom version number in advanced workflows
-if [[ -z "$VERSION" ]]; then
+# Allow setting custom version number in advanced workflows.
+# By default, only derive VERSION from tag refs; branch refs will
+# result in an empty VERSION so we can support trunk-only deployments.
+if [[ -z "$VERSION" && "$GITHUB_REF" == refs/tags/* ]]; then
 	VERSION="${GITHUB_REF#refs/tags/}"
 	VERSION="${VERSION#v}"
 fi
-echo "ℹ︎ VERSION is $VERSION"
+if [[ -n "$VERSION" ]]; then
+	echo "ℹ︎ VERSION is $VERSION"
+else
+	echo "ℹ︎ VERSION is not set; trunk-only deployment assumed unless overridden."
+fi
 
 if [[ -z "$ASSETS_DIR" ]]; then
 	ASSETS_DIR=".wordpress-org"
@@ -118,7 +124,9 @@ generate_zip() {
 }
 
 # Bail early if the plugin version is already published.
-if [[ -d "tags/$VERSION" ]]; then
+# Only relevant when we are creating a new tag, not for
+# trunk-only deployments where VERSION may be empty.
+if [[ ! $INPUT_TRUNK_ONLY && -n "$VERSION" && -d "tags/$VERSION" ]] then
 	echo "ℹ︎ Version $VERSION of plugin $SLUG was already published";
 
 	generate_zip
@@ -203,9 +211,12 @@ svn add . --force > /dev/null
 # Also suppress stdout here
 svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
 
-# Copy tag locally to make this a single commit
-echo "➤ Copying tag..."
-svn cp "trunk" "tags/$VERSION"
+# Copy tag locally to make this a single commit when not
+# doing a trunk-only deployment.
+if [[ -n "$VERSION" && ! $INPUT_TRUNK_ONLY ]] then
+	echo "➤ Copying tag..."
+	svn cp trunk "tags/$VERSION"
+fi
 
 # Fix screenshots getting force downloaded when clicking them
 # https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
@@ -231,7 +242,13 @@ if $INPUT_DRY_RUN; then
   echo "➤ Dry run: Files not committed."
 else
   echo "➤ Committing files..."
-  svn commit -m "Update to version $VERSION from GitHub" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+  COMMIT_MSG="Update from GitHub"
+  if [[ -n "$VERSION" && ! $INPUT_TRUNK_ONLY ]] then
+    COMMIT_MSG="Update to version $VERSION from GitHub"
+  fi
+
+  svn commit -m "$COMMIT_MSG" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 fi
 
 generate_zip

--- a/examples/deploy-on-tag-and-branch.yml
+++ b/examples/deploy-on-tag-and-branch.yml
@@ -18,11 +18,11 @@ jobs:
         run: |
           npm install
           npm run build
-        # Deploy to both tags and trunk on tag, or only to trunk on trunk branch.
+        # Deploy to both tags and trunk on tag, or only to trunk on main branch.
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         with:
-          trunk-only: ${{ github.ref_name == 'trunk' }}
+          trunk-only: ${{ github.ref_name == 'main' }}
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/examples/deploy-on-tag-and-branch.yml
+++ b/examples/deploy-on-tag-and-branch.yml
@@ -1,0 +1,28 @@
+name: Deploy readme and assets to WordPress.org
+on:
+  push:
+    branches:
+      # Or use your primary branch name, e.g. main, trunk, master
+      - main
+    tags:
+      # On all tags.
+jobs:
+  trunk_only_deploy:
+    name: Trunk-only deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        # Optional build step; remove or customize as needed.
+      - name: Build
+        run: |
+          npm install
+          npm run build
+        # Deploy to both tags and trunk on tag, or only to trunk on trunk branch.
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          trunk-only: ${{ github.ref_name == 'trunk' }}
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Implement a `trunk-only` action input that skips the tag deploy and pushes to SVN `trunk` and `assets` only.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #103

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Setup an action with `trunk-only: true` and confirm that the updates were sent only to the `trunk` and `asset` branches without releasing a tag on SVN.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Support for trunk-only deploys that useful for updates to plugin assets (icon, graphics) and "Tested up to" version without doing full releases.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kasparsd

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
