### PR TITLE
Fix svn status parsing for paths with extra status flags

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -201,7 +201,7 @@ svn add . --force > /dev/null
 
 # SVN delete all deleted files
 # Also suppress stdout here
-svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
+svn status | grep '^\!' | cut -c9- | xargs -I% svn rm %@ > /dev/null
 
 # Copy tag locally to make this a single commit
 echo "➤ Copying tag..."


### PR DESCRIPTION
## Summary

Fixes the `sed 's/! *//'` regex on line 204 of `deploy.sh` which fails to correctly parse `svn status` output when columns 2-7 contain non-space status flags (e.g. `L` for locked).

**Root cause:** `svn status` output uses 7 fixed-width single-character columns followed by a space before the path. The current `sed` regex strips `!` plus trailing spaces, but stops at any non-space character in columns 2-7, producing invalid paths like `L    trunk/views/...`.

**Fix:** Replace `sed 's/! *//'` with `cut -c9-` which extracts from character 9 onward — always the start of the path regardless of status flags.

```diff
-svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
+svn status | grep '^\!' | cut -c9- | xargs -I% svn rm %@ > /dev/null
```

## Details

`svn status` format ([docs](https://svnbook.red-bean.com/en/1.8/svn.ref.svn.c.status.html)):
```
!  L    trunk/views/components/modals
^^^^^^^
cols 1-7 = status flags, col 8 = space, col 9+ = path
```

The `sed` approach works in the common case (columns 2-7 are spaces), but breaks when any flag is set — such as `L` (locked) which can appear during checkout operations in CI.

**Real-world failure:** This caused `svn: E155007` errors when deploying [WP SMS v7.2](https://wordpress.org/plugins/wp-sms/) which added a new `views/` directory tree. The locked entries during `svn add` left `L` flags that corrupted the subsequent `svn rm` paths.

## Verification

- `cut -c9-` produces identical output to `sed 's/! *//'` when columns 2-7 are all spaces (the common case)
- `cut -c9-` correctly handles all status flag combinations (locked, switched, conflicted, etc.)
- The 8-character prefix width is part of SVN's stable output format

Fixes #134